### PR TITLE
Reduce embedded IPFS node resource usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on: push
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   lint:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Overview
+
+Go library (single package `ipfs`, module `github.com/dipdup-io/ipfs-tools`) for fetching data from IPFS. No binaries — library only. Two independent entry points:
+
+- **`Pool`** ([pool.go](pool.go)) — fetches content over HTTP from a list of IPFS gateways. Per-gateway rate limiting (10 rps via `golang.org/x/time/rate`), responses capped by a byte `limit` through `io.LimitReader`. Implements the `IPool` interface.
+- **`Node`** ([node.go](node.go)) — embedded in-process Kubo node. `applySettings` deliberately minimizes resource usage (relay/QUIC off, delegated routing, providing and Bitswap server off, ConnMgr 20/50, 2GB storage, hourly GC) — keep that intent when touching the config.
+
+Supporting files: [functions.go](functions.go) — link parsing/validation helpers (`Hash`, `Link`, `Path`, `FindAllLinks`, `Is`, `ShuffleGateways`); [data.go](data.go) — `Data` and `Provider` types; [errors.go](errors.go) — sentinel errors (`ErrInvalidCID`, `ErrNoIPFSResponse`, …).
+
+## Commands
+
+```bash
+make test        # go test ./...
+make lint        # golangci-lint run (v2 config in .golangci.yml)
+go generate ./...  # regenerate mock_pool.go via mockgen (go.uber.org/mock)
+```
+
+Run a single test: `go test -run TestName ./...`
+
+## Conventions
+
+- Errors: wrap with `github.com/pkg/errors` (`errors.Wrap`/`Wrapf`); define sentinel errors in [errors.go](errors.go).
+- Logging: `github.com/rs/zerolog/log` global logger.
+- Mocks: `mock_pool.go` is generated — never edit by hand; change the `IPool` interface in [pool.go](pool.go) and run `go generate`.
+- Linting is strict (gosec, gocritic, noctx, etc. — see [.golangci.yml](.golangci.yml)); always pass `context.Context` into HTTP requests.
+- CI: GitHub Actions runs lint + tests on every push ([.github/workflows/test.yml](.github/workflows/test.yml)); tags `v*.*.*` trigger a GitHub release.
+
+## Notes
+
+- `Node.Get` expects a path accepted by `boxopath.NewPath` (e.g. `/ipfs/<cid>`), while `Pool` methods take `ipfs://<cid>` links — don't conflate the two.
+- Kubo plugin loading in `spawn` uses `sync.Once`; only one plugin setup per process is possible.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,125 @@
 # ipfs-tools
-Tools for IPFS
+
+[![Tests](https://github.com/dipdup-io/ipfs-tools/actions/workflows/test.yml/badge.svg)](https://github.com/dipdup-io/ipfs-tools/actions/workflows/test.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/dipdup-io/ipfs-tools.svg)](https://pkg.go.dev/github.com/dipdup-io/ipfs-tools)
+
+Go library for fetching data from IPFS. It provides two ways to resolve content:
+
+- **Gateway pool** — fetch documents over HTTP from a list of public/private IPFS gateways with per-gateway rate limiting;
+- **Embedded node** — run an in-process [Kubo](https://github.com/ipfs/kubo) IPFS node tuned for low resource usage and fetch content directly from the network.
+
+Plus a set of helpers for parsing and validating `ipfs://` links.
+
+## Installation
+
+```bash
+go get github.com/dipdup-io/ipfs-tools
+```
+
+## Usage
+
+### Gateway pool
+
+`Pool` requests content from HTTP gateways. Each gateway gets its own rate limiter (10 requests per second). Response size is capped by `limit` (bytes).
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	ipfs "github.com/dipdup-io/ipfs-tools"
+)
+
+func main() {
+	pool, err := ipfs.NewPool([]string{
+		"https://ipfs.io",
+		"https://cloudflare-ipfs.com",
+	}, 1024*1024) // 1 MB response limit
+	if err != nil {
+		panic(err)
+	}
+
+	// tries gateways in random order until one responds
+	data, err := pool.Get(context.Background(), "ipfs://QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("received %d bytes from %s\n", len(data.Raw), data.Node)
+}
+```
+
+Other ways to query the pool:
+
+```go
+// single request to one randomly chosen gateway
+data, err := pool.GetFromRandomGateway(ctx, link)
+
+// request to a specific gateway
+data, err := pool.GetFromNode(ctx, link, "https://ipfs.io")
+```
+
+The pool implements the `IPool` interface; a `gomock` mock (`MockIPool`) is shipped with the package for testing.
+
+### Embedded IPFS node
+
+`Node` spawns an in-process Kubo node. The repo config is tuned to minimize resource usage: no relay/QUIC transports, delegated routing, providing and Bitswap server disabled, connection manager capped at 20–50 peers, 2 GB storage with hourly GC.
+
+```go
+node, err := ipfs.NewNode(ctx,
+	"/path/to/ipfs-repo",       // repo directory (created if missing)
+	1024*1024,                  // read limit in bytes
+	[]string{},                 // swarm address blacklist (addr filters)
+	[]ipfs.Provider{            // peers to keep persistent connections with
+		{ID: "12D3KooW...", Address: "/dns4/example.com/tcp/4001"},
+	},
+)
+if err != nil {
+	panic(err)
+}
+
+if err := node.Start(ctx); err != nil { // connects to peers, starts periodic GC
+	panic(err)
+}
+defer node.Close()
+
+data, err := node.Get(ctx, "/ipfs/QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU")
+```
+
+### Helpers
+
+```go
+// extract and validate a CID from a link
+hash, err := ipfs.Hash("ipfs://QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU")
+
+// find all ipfs:// links (CIDv0 and CIDv1) in raw bytes
+links := ipfs.FindAllLinks(data)
+
+// check whether a string is a valid ipfs:// link
+ok := ipfs.Is("ipfs://QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU")
+
+// build a gateway URL from gateway address and hash
+url := ipfs.Link("https://ipfs.io", hash) // https://ipfs.io/ipfs/<hash>
+
+// strip the ipfs:// prefix
+path := ipfs.Path("ipfs://<hash>") // <hash>
+```
+
+## Development
+
+```bash
+make test   # go test ./...
+make lint   # golangci-lint run
+```
+
+Mocks are generated with [mockgen](https://github.com/uber-go/mock):
+
+```bash
+go generate ./...
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/node.go
+++ b/node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ipfs/boxo/files"
 	boxopath "github.com/ipfs/boxo/path"
 	icore "github.com/ipfs/kubo/core/coreiface"
+	"github.com/ipfs/kubo/core/corerepo"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -20,6 +21,7 @@ import (
 	"github.com/ipfs/kubo/core"
 	"github.com/ipfs/kubo/core/coreapi"
 	"github.com/ipfs/kubo/plugin/loader" // This package is needed so that all the preloaded plugins are loaded automatically
+	"github.com/ipfs/kubo/repo"
 	"github.com/ipfs/kubo/repo/fsrepo"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -30,7 +32,7 @@ type Node struct {
 	node      *core.IpfsNode
 	providers []Provider
 	limit     int64
-	wg        *sync.WaitGroup
+	wg        sync.WaitGroup
 }
 
 // NewNode -
@@ -44,12 +46,11 @@ func NewNode(ctx context.Context, dir string, limit int64, blacklist []string, p
 		node:      node,
 		providers: providers,
 		limit:     limit,
-		wg:        new(sync.WaitGroup),
 	}, nil
 }
 
 // Start -
-func (n *Node) Start(ctx context.Context, bootstrap ...string) error {
+func (n *Node) Start(ctx context.Context) error {
 	log.Info().Msg("going to connect to bootstrap nodes...")
 
 	connected, err := n.api.Swarm().Peers(ctx)
@@ -64,8 +65,11 @@ func (n *Node) Start(ctx context.Context, bootstrap ...string) error {
 			Msg("connected to peer")
 	}
 
-	n.wg.Add(1)
-	go n.reconnect(ctx)
+	n.wg.Go(func() {
+		if err := corerepo.PeriodicGC(ctx, n.node); err != nil && !errors.Is(err, context.Canceled) {
+			log.Err(err).Msg("ipfs periodic gc")
+		}
+	})
 
 	return nil
 }
@@ -119,12 +123,11 @@ func spawn(ctx context.Context, dir string, blacklist []string, providers []Prov
 		return nil, nil, onceErr
 	}
 
-	repoPath, err := createRepository(dir, blacklist, providers)
-	if err != nil {
+	if err := createRepository(dir); err != nil {
 		return nil, nil, err
 	}
 
-	r, err := fsrepo.Open(repoPath)
+	r, err := openRepository(dir, blacklist, providers)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -144,51 +147,81 @@ func spawn(ctx context.Context, dir string, blacklist []string, providers []Prov
 	return api, node, err
 }
 
-func createRepository(dir string, blacklist []string, providers []Provider) (string, error) {
-	if _, err := os.Stat(dir); err != nil {
-		if os.IsNotExist(err) {
-			if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-				return "", fmt.Errorf("failed to get dir: %s", err)
-			}
-		} else {
-			return "", err
-		}
-	}
-
-	// Create a config with default options and a 2048 bit key
-	cfg, err := config.Init(io.Discard, 2048)
+// openRepository opens an initialized repo and persists the current settings into its config.
+func openRepository(dir string, blacklist []string, providers []Provider) (repo.Repo, error) {
+	r, err := fsrepo.Open(dir)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
+	if err := updateRepoConfig(r, blacklist, providers); err != nil {
+		if closeErr := r.Close(); closeErr != nil {
+			log.Err(closeErr).Msg("closing ipfs repo")
+		}
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func updateRepoConfig(r repo.Repo, blacklist []string, providers []Provider) error {
+	current, err := r.Config()
+	if err != nil {
+		return err
+	}
+
+	updated, err := current.Clone()
+	if err != nil {
+		return err
+	}
+	if err := applySettings(updated, blacklist, providers); err != nil {
+		return err
+	}
+
+	return r.SetConfig(updated)
+}
+
+func applySettings(cfg *config.Config, blacklist []string, providers []Provider) error {
 	cfg.Swarm.DisableBandwidthMetrics = true
 	cfg.Swarm.Transports.Network.Relay = config.False
 	cfg.Swarm.Transports.Network.QUIC = config.False
 	cfg.Swarm.AddrFilters = blacklist
-	cfg.Swarm.ConnMgr.HighWater = config.NewOptionalInteger(50)
 	cfg.Swarm.ConnMgr.LowWater = config.NewOptionalInteger(20)
+	cfg.Swarm.ConnMgr.HighWater = config.NewOptionalInteger(50)
 	cfg.Swarm.ConnMgr.GracePeriod = config.NewOptionalDuration(time.Minute)
+
 	cfg.Routing.AcceleratedDHTClient = config.False
-	cfg.Routing.Type = config.NewOptionalString("dhtclient")
+	cfg.Routing.Type = config.NewOptionalString("delegated")
+	cfg.Routing.DelegatedRouters = []string{"auto"}
+
 	cfg.Provide.Enabled = config.False
 	cfg.Bitswap.ServerEnabled = config.False
+
 	cfg.Datastore.StorageMax = "2GB"
 	cfg.Datastore.GCPeriod = "1h"
 
 	peers, err := providersToAddrInfo(providers)
 	if err != nil {
-		return "", errors.Wrap(err, "collecting providers info error")
+		return errors.Wrap(err, "collecting providers info")
 	}
-	cfg.Peering = config.Peering{
-		Peers: peers,
+	cfg.Peering = config.Peering{Peers: peers}
+	return nil
+}
+
+func createRepository(dir string) error {
+	if fsrepo.IsInitialized(dir) {
+		return nil
+	}
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return errors.Wrap(err, "failed to create dir")
 	}
 
-	// Create the repo with the config
-	if err = fsrepo.Init(dir, cfg); err != nil {
-		return "", errors.Wrap(err, "failed to init node")
+	cfg, err := config.Init(io.Discard, 2048)
+	if err != nil {
+		return errors.Wrap(err, "config init")
 	}
 
-	return dir, nil
+	return errors.Wrap(fsrepo.Init(dir, cfg), "failed to init node")
 }
 
 func setupPlugins(externalPluginsPath string) error {
@@ -208,30 +241,6 @@ func setupPlugins(externalPluginsPath string) error {
 	}
 
 	return nil
-}
-
-func (n *Node) reconnect(ctx context.Context) {
-	defer n.wg.Done()
-
-	ticker := time.NewTicker(time.Minute * 3)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			peers, err := n.api.Swarm().Peers(ctx)
-			if err != nil {
-				log.Err(err).Msg("receiving peers")
-				continue
-			}
-
-			for _, pi := range peers {
-				log.Info().Str("peer_id", pi.ID().String()).Str("address", pi.Address().String()).Msg("connected to peer")
-			}
-		}
-	}
 }
 
 func providersToAddrInfo(providers []Provider) ([]peer.AddrInfo, error) {

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,171 @@
+package ipfs
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ipfs/kubo/config"
+	configserialize "github.com/ipfs/kubo/config/serialize"
+	"github.com/ipfs/kubo/repo/fsrepo"
+)
+
+// well-known kubo bootstrap peer, used only as a syntactically valid fixture
+const testProviderID = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+
+func loadTestPlugins(t *testing.T) {
+	t.Helper()
+
+	var err error
+	loadPluginsOnce.Do(func() {
+		err = setupPlugins("")
+	})
+	if err != nil {
+		t.Fatalf("setupPlugins: %v", err)
+	}
+}
+
+func readDiskConfig(t *testing.T, dir string) *config.Config {
+	t.Helper()
+
+	var cfg config.Config
+	if err := configserialize.ReadConfigFile(filepath.Join(dir, "config"), &cfg); err != nil {
+		t.Fatalf("reading repo config: %v", err)
+	}
+	return &cfg
+}
+
+func TestCreateRepositoryInitializesOnce(t *testing.T) {
+	loadTestPlugins(t)
+	dir := t.TempDir()
+
+	if err := createRepository(dir); err != nil {
+		t.Fatalf("createRepository: %v", err)
+	}
+	if !fsrepo.IsInitialized(dir) {
+		t.Fatal("repo is not initialized after createRepository")
+	}
+
+	first := readDiskConfig(t, dir)
+	if first.Identity.PeerID == "" {
+		t.Fatal("fresh repo has empty PeerID")
+	}
+
+	if err := createRepository(dir); err != nil {
+		t.Fatalf("createRepository on existing repo: %v", err)
+	}
+
+	second := readDiskConfig(t, dir)
+	if first.Identity.PeerID != second.Identity.PeerID {
+		t.Fatalf("identity was regenerated: %s != %s", first.Identity.PeerID, second.Identity.PeerID)
+	}
+}
+
+func TestOpenRepositoryPersistsSettings(t *testing.T) {
+	loadTestPlugins(t)
+	dir := t.TempDir()
+
+	if err := createRepository(dir); err != nil {
+		t.Fatalf("createRepository: %v", err)
+	}
+
+	blacklist := []string{"/ip4/10.0.0.0/ipcidr/8"}
+	providers := []Provider{{ID: testProviderID, Address: "/ip4/104.131.131.82/tcp/4001"}}
+
+	r, err := openRepository(dir, blacklist, providers)
+	if err != nil {
+		t.Fatalf("openRepository: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("repo close: %v", err)
+	}
+
+	cfg := readDiskConfig(t, dir)
+
+	if got := cfg.Routing.Type.WithDefault(""); got != "delegated" {
+		t.Errorf("Routing.Type = %q, want %q", got, "delegated")
+	}
+	if len(cfg.Routing.DelegatedRouters) != 1 || cfg.Routing.DelegatedRouters[0] != "auto" {
+		t.Errorf("Routing.DelegatedRouters = %v, want [auto]", cfg.Routing.DelegatedRouters)
+	}
+	if cfg.Provide.Enabled.WithDefault(true) {
+		t.Error("Provide.Enabled must be persisted as false")
+	}
+	if cfg.Bitswap.ServerEnabled.WithDefault(true) {
+		t.Error("Bitswap.ServerEnabled must be persisted as false")
+	}
+	if cfg.Datastore.StorageMax != "2GB" {
+		t.Errorf("Datastore.StorageMax = %q, want 2GB", cfg.Datastore.StorageMax)
+	}
+	if cfg.Datastore.GCPeriod != "1h" {
+		t.Errorf("Datastore.GCPeriod = %q, want 1h", cfg.Datastore.GCPeriod)
+	}
+	if got := cfg.Swarm.ConnMgr.LowWater.WithDefault(0); got != 20 {
+		t.Errorf("Swarm.ConnMgr.LowWater = %d, want 20", got)
+	}
+	if got := cfg.Swarm.ConnMgr.HighWater.WithDefault(0); got != 50 {
+		t.Errorf("Swarm.ConnMgr.HighWater = %d, want 50", got)
+	}
+	if len(cfg.Swarm.AddrFilters) != 1 || cfg.Swarm.AddrFilters[0] != blacklist[0] {
+		t.Errorf("Swarm.AddrFilters = %v, want %v", cfg.Swarm.AddrFilters, blacklist)
+	}
+	if len(cfg.Peering.Peers) != 1 || cfg.Peering.Peers[0].ID.String() != testProviderID {
+		t.Errorf("Peering.Peers = %v, want single peer %s", cfg.Peering.Peers, testProviderID)
+	}
+}
+
+func TestOpenRepositoryOverridesStaleConfig(t *testing.T) {
+	loadTestPlugins(t)
+	dir := t.TempDir()
+
+	if err := createRepository(dir); err != nil {
+		t.Fatalf("createRepository: %v", err)
+	}
+	before := readDiskConfig(t, dir)
+
+	// simulate a repo left behind by an older ipfs-tools version
+	r, err := fsrepo.Open(dir)
+	if err != nil {
+		t.Fatalf("fsrepo.Open: %v", err)
+	}
+	stale, err := r.Config()
+	if err != nil {
+		t.Fatalf("repo config: %v", err)
+	}
+	staleCopy, err := stale.Clone()
+	if err != nil {
+		t.Fatalf("config clone: %v", err)
+	}
+	staleCopy.Routing.Type = config.NewOptionalString("dhtclient")
+	staleCopy.Swarm.ConnMgr.HighWater = config.NewOptionalInteger(150)
+	if err := r.SetConfig(staleCopy); err != nil {
+		t.Fatalf("seeding stale config: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("repo close: %v", err)
+	}
+
+	r, err = openRepository(dir, nil, nil)
+	if err != nil {
+		t.Fatalf("openRepository: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("repo close: %v", err)
+	}
+
+	after := readDiskConfig(t, dir)
+	if got := after.Routing.Type.WithDefault(""); got != "delegated" {
+		t.Errorf("stale Routing.Type was not overridden: got %q", got)
+	}
+	if got := after.Swarm.ConnMgr.HighWater.WithDefault(0); got != 50 {
+		t.Errorf("stale Swarm.ConnMgr.HighWater was not overridden: got %d", got)
+	}
+	if after.Identity.PeerID != before.Identity.PeerID {
+		t.Fatalf("identity changed on config update: %s != %s", before.Identity.PeerID, after.Identity.PeerID)
+	}
+}
+
+func TestApplySettingsInvalidProvider(t *testing.T) {
+	if err := applySettings(&config.Config{}, nil, []Provider{{ID: "not-a-peer-id"}}); err == nil {
+		t.Fatal("expected error for invalid provider ID")
+	}
+}


### PR DESCRIPTION
Profiling a metadata-indexer instance showed that ~95% of memory (~2GB RSS) and CPU
was consumed by the embedded IPFS node acting as a full network participant:
announcing every cached block to the DHT and serving blocks to other peers.

### Changes

- **Apply config to existing repositories.** `fsrepo.Init` is a no-op when the repo
  already exists, so config changes in code never reached deployed nodes. The config
  is now persisted on every start via `repo.SetConfig` (identity is preserved).
- **Disable providing and bitswap server** (`Provide.Enabled=false`,
  `Bitswap.ServerEnabled=false`) — the node is a pure consumer.
- **Switch to delegated routing** (`Routing.Type=delegated`) — provider lookups go
  through HTTP routers instead of running a DHT client.
- **Lower connection manager watermarks** to 20/50 with a 1m grace period.
- **Bound the datastore**: `StorageMax=2GB` + a periodic GC goroutine
  (`corerepo.PeriodicGC`); the `enable-gc` ExtraOpt is daemon-only and had no effect.
- **Skip repo re-initialization** on start when it already exists (avoids generating
  and discarding an RSA key on every launch).
- Remove the `reconnect` goroutine that logged the full peer list every 3 minutes.

### Tests

Added tests covering repo creation (idempotency, identity preservation) and config
persistence/override on existing repos — no node startup or network required.